### PR TITLE
Consolidate build functions with default opts, convert opts to Keyword

### DIFF
--- a/lib/calendarize.ex
+++ b/lib/calendarize.ex
@@ -9,10 +9,11 @@ defmodule Calendarize do
   @type build_options :: [week_start: Timex.Types.weekstart()]
 
   @doc """
-  Generates a calendar month array given a Date or DateTime
+  Generates a calendar month array given a date. Currently, `week_start` is the only option, and it can be any integer 1..7 or
+  any string accepted by [Timex.day_to_num()](https://hexdocs.pm/timex/Timex.html#day_to_num/1). If not specified, `week_start`
+  defaults to :sun
 
   ## Examples
-
       iex> Calendarize.build(~D[2020-05-15])
       [
         [0, 0, 0, 0, 0, 1, 2],
@@ -23,34 +24,7 @@ defmodule Calendarize do
         [31, 0, 0, 0, 0, 0, 0]
       ]
 
-      iex> Calendarize.build(Timex.now)
-      [
-        [0, 0, 0, 0, 0, 1, 2],
-        [3, 4, 5, 6, 7, 8, 9],
-        [10, 11, 12, 13, 14, 15, 16],
-        [17, 18, 19, 20, 21, 22, 23],
-        [24, 25, 26, 27, 28, 29, 30],
-        [31, 0, 0, 0, 0, 0, 0]
-      ]
-  """
-  @spec build(Date.t() | DateTime.t()) :: list()
-  def build(%Date{} = date) do
-    get_dates(date, :sun)
-  end
-
-  def build(%DateTime{} = date) do
-    get_dates(date, :sun)
-  end
-
-  def build(_) do
-    raise("Must pass a valid Date or DateTime")
-  end
-
-  @doc """
-  Generates a calendar month array given a date. Currently, `week_start` is the only option, and it can be any integer 1..7 or
-  any string accepted by [Timex.day_to_num()](https://hexdocs.pm/timex/Timex.html#day_to_num/1)
-  ## Examples
-      iex> Calendarize.build(~D[2020-05-15], %{:week_start => :mon})
+      iex> Calendarize.build(~D[2020-05-15], week_start: :mon)
       [
         [0, 0, 0, 0, 1, 2, 3],
         [4, 5, 6, 7, 8, 9, 10],
@@ -60,7 +34,7 @@ defmodule Calendarize do
         [0, 0, 0, 0, 0, 0, 0]
       ]
 
-      iex> Calendarize.build(Timex.now, %{:week_start => :mon})
+      iex> Calendarize.build(Timex.now, week_start: :mon)
       [
         [0, 0, 0, 0, 1, 2, 3],
         [4, 5, 6, 7, 8, 9, 10],
@@ -71,12 +45,8 @@ defmodule Calendarize do
       ]
   """
   @spec build(DateTime.t() | Date.t(), build_options()) :: list()
-  def build(%DateTime{} = date, %{:week_start => week_start} = _options) do
-    get_dates(date, week_start)
-  end
-
-  def build(%Date{} = date, %{:week_start => week_start} = _options) do
-    get_dates(date, week_start)
+  def build(%dt{} = date, opts \\ []) when dt in [DateTime, Date] do
+    get_dates(date, Keyword.get(opts, :week_start, :sun))
   end
 
   defp get_dates(date, week_start) do
@@ -92,8 +62,9 @@ defmodule Calendarize do
   end
 
   defp get_date(week, day_in_week, start_day, end_day) do
-    day_in_month = (((week - 1) * 7) + day_in_week)
-    if (day_in_month < start_day) or (day_in_month > (end_day + start_day - 1)) do
+    day_in_month = (week - 1) * 7 + day_in_week
+
+    if day_in_month < start_day or day_in_month > end_day + start_day - 1 do
       0
     else
       day_in_month - start_day + 1

--- a/mix.exs
+++ b/mix.exs
@@ -21,10 +21,10 @@ defmodule Calendarize.MixProject do
       app: :calendarize,
       version: "0.1.0",
       elixir: "~> 1.10",
-      build_embedded: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      description: description,
-      package: package,
+      description: description(),
+      package: package(),
       deps: deps()
     ]
   end


### PR DESCRIPTION
I saw your post on Reddit, welcome to the Elixir community! Thanks for creating this library, it is a great way to get into the language. You have done a great job, I wanted to encourage and help you by giving you some constructive feedback. This PR contains some suggestions for making the code a bit simpler and more idiomatic to Elixir.

1) The opts are swapped to a keyword list. It is more idiomatic in Elixir to use keywords for opts vs a map, because it is cleaner for the caller to specify `week_start: :mon` than `%{:week_start => :mon}`.

2) Consolidated the single and double arity functions into a double arity function with a default value:
```elixir
def build(date, opts \\ []) do
  ...
end
```
is syntactic sugar that, when compiled, expands to:
```elixir
def build(date) do
  build(date, [])
end

def build(date, opts) do
  ..
end
```

3) Pull the week out of opts and specify a default at the same time:
```elixir
Keyword.get(opts, :week_start, :sun)
```
will get the `:week_start` value from the `opts` keyword, and if it is not there, return `:sun`. Combined with the default `opts \\ []` it will work and return `:sun` even if the caller didn't specify any opts.

4) Combine the `Date` and `DateTime` functions into a single function:
```elixir
def build(%dt{} = date, opts \\ []) when dt in [DateTime, Date] do
```
This uses the power of pattern matching to match this function on both a `Date` and a `DateTime` module.

5) Removed the explicit catch-all & raise `build(_)`. It is idiomatic in Elixir to pattern match on values you are going to accept, and not have a catch-all for those you don't expect. This will result in a helpful message like this:
<img width="542" alt="Screen Shot 2020-05-21 at 8 58 33 AM" src="https://user-images.githubusercontent.com/8557871/82561582-a1ec0300-9b41-11ea-93bb-900324ede786.png">
compared to the explicit raise:
<img width="466" alt="Screen Shot 2020-05-21 at 8 59 46 AM" src="https://user-images.githubusercontent.com/8557871/82561592-a7494d80-9b41-11ea-98ec-5bd467fee7b6.png">
This extra detail can be a lifesaver when you are dealing with more complex function heads and you find yourself thinking "but I am pretty sure I *am* passing a valid Date or DateTime"


Again, welcome to the Elixir community, and feel free to @ tag me on pull requests for advice, or find me in [Elixir Slack](https://join.slack.com/t/elixir-lang/shared_invite/zt-eivteker-k_nArD59XHjjN_r8qeH6dw) (same handle as GH)